### PR TITLE
Unrwap

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -194,3 +194,8 @@ func GetRootError(err error) error {
 	}
 	return err
 }
+
+// Unwrap unwraps root error.
+func (n NCError) Unwrap() error {
+	return n.RootError
+}

--- a/errors/error.go
+++ b/errors/error.go
@@ -195,7 +195,7 @@ func GetRootError(err error) error {
 	return err
 }
 
-// Unwrap unwraps root error.
+// Unwrap returns underlying non-NCError error. If no errors were wrapped by NCError then returns nil.
 func (n NCError) Unwrap() error {
 	return n.RootError
 }


### PR DESCRIPTION
Implements Unwrap method for NCError to comply with golang 1.13.