### PR TITLE
Add two methods to extend existing errors.Fields by new keys

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -41,7 +41,7 @@ func (f Fields) copy() Fields {
 	return newFields
 }
 
-//Add adds key:val to the Fields, returns copy
+// Add adds key:val to the Fields, returns copy.
 func (f Fields) Add(key string, val interface{}) Fields {
 	newFields := f.copy()
 	newFields[key] = val

--- a/errors/error.go
+++ b/errors/error.go
@@ -33,22 +33,14 @@ func ListToError(errs []error) error {
 // Fields keeps context.
 type Fields map[string]interface{}
 
-func (f Fields) copy() Fields {
-	newFields := make(map[string]interface{})
-	for k, v := range f {
-		newFields[k] = v
-	}
-	return newFields
-}
-
-// Add adds key:val to the Fields, returns copy.
+// Add adds key:val to the Fields, returns fresh extended copy. The original Fields remains intact.
 func (f Fields) Add(key string, val interface{}) Fields {
 	newFields := f.copy()
 	newFields[key] = val
 	return newFields
 }
 
-//Extend extends Fields with the content of extFields, returns copy
+// Extend extends Fields with the content of extFields, returns fresh extended copy. The original Fields remains intact.
 func (f Fields) Extend(extFields Fields) Fields {
 	newFields := f.copy()
 	for k, v := range extFields {
@@ -57,7 +49,15 @@ func (f Fields) Extend(extFields Fields) Fields {
 	return newFields
 }
 
-// Cause keeps the context information about the error
+func (f Fields) copy() Fields {
+	newFields := make(map[string]interface{}, len(f))
+	for k, v := range f {
+		newFields[k] = v
+	}
+	return newFields
+}
+
+// Cause keeps the context information about the error.
 type Cause struct {
 	Message  string
 	Fields   Fields
@@ -67,7 +67,7 @@ type Cause struct {
 	Severity LogSeverity
 }
 
-// NCError basic error structure
+// NCError basic error structure.
 type NCError struct {
 	Causes []Cause
 	// Contains stack trace from the initial place when the error
@@ -85,7 +85,7 @@ func (n NCError) Error() string {
 	return strings.Join(messages, ": ")
 }
 
-//New error with context.
+// New error with context.
 func New(message string, fields Fields) error {
 	fileName, funcName, lineNumber := GetRuntimeContext()
 	newCause := Cause{

--- a/errors/error.go
+++ b/errors/error.go
@@ -33,6 +33,30 @@ func ListToError(errs []error) error {
 // Fields keeps context.
 type Fields map[string]interface{}
 
+func (f Fields) copy() Fields {
+	newFields := make(map[string]interface{})
+	for k, v := range f {
+		newFields[k] = v
+	}
+	return newFields
+}
+
+//Add adds key:val to the Fields, returns copy
+func (f Fields) Add(key string, val interface{}) Fields {
+	newFields := f.copy()
+	newFields[key] = val
+	return newFields
+}
+
+//Extend extends Fields with the content of extFields, returns copy
+func (f Fields) Extend(extFields Fields) Fields {
+	newFields := f.copy()
+	for k, v := range extFields {
+		newFields[k] = v
+	}
+	return newFields
+}
+
 // Cause keeps the context information about the error
 type Cause struct {
 	Message  string

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -198,3 +198,19 @@ func TestGetRootError(t *testing.T) {
 		}
 	}
 }
+
+func TestFieldsAdd(t *testing.T) {
+	fields := Fields{"key1": "val1", "key2": "val2"}
+	extFields := fields.Add("key3", "val3")
+	assert.Equal(t, "val3", extFields["key3"])
+	assert.Equal(t, nil, fields["key3"])
+}
+
+func TestFieldsExtend(t *testing.T) {
+	fields := Fields{"key1": "val1", "key2": "val2"}
+	extFields := fields.Extend(Fields{"key3": "val3", "key4": "val4"})
+	assert.Equal(t, "val3", extFields["key3"])
+	assert.Equal(t, "val4", extFields["key4"])
+	assert.Equal(t, nil, fields["key3"])
+	assert.Equal(t, nil, fields["key4"])
+}

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -204,6 +204,8 @@ func TestFieldsAdd(t *testing.T) {
 	extFields := fields.Add("key3", "val3")
 	expectedFields := Fields{"key1": "val1", "key2": "val2", "key3": "val3"}
 	assert.Equal(t, expectedFields, extFields)
+
+	// Check if the original fields remain intact.
 	assert.Equal(t, nil, fields["key3"])
 }
 
@@ -213,7 +215,7 @@ func TestFieldsExtend(t *testing.T) {
 	expectedFields := Fields{"key1": "val1", "key2": "val2", "key3": "val3", "key4": "val4"}
 	assert.Equal(t, expectedFields, extFields)
 
-	// Check if
+	// Check if the original fields remain intact.
 	assert.Equal(t, nil, fields["key3"])
 	assert.Equal(t, nil, fields["key4"])
 }

--- a/errors/error_test.go
+++ b/errors/error_test.go
@@ -202,15 +202,18 @@ func TestGetRootError(t *testing.T) {
 func TestFieldsAdd(t *testing.T) {
 	fields := Fields{"key1": "val1", "key2": "val2"}
 	extFields := fields.Add("key3", "val3")
-	assert.Equal(t, "val3", extFields["key3"])
+	expectedFields := Fields{"key1": "val1", "key2": "val2", "key3": "val3"}
+	assert.Equal(t, expectedFields, extFields)
 	assert.Equal(t, nil, fields["key3"])
 }
 
 func TestFieldsExtend(t *testing.T) {
 	fields := Fields{"key1": "val1", "key2": "val2"}
 	extFields := fields.Extend(Fields{"key3": "val3", "key4": "val4"})
-	assert.Equal(t, "val3", extFields["key3"])
-	assert.Equal(t, "val4", extFields["key4"])
+	expectedFields := Fields{"key1": "val1", "key2": "val2", "key3": "val3", "key4": "val4"}
+	assert.Equal(t, expectedFields, extFields)
+
+	// Check if
 	assert.Equal(t, nil, fields["key3"])
 	assert.Equal(t, nil, fields["key4"])
 }

--- a/errors/stack_trace_test.go
+++ b/errors/stack_trace_test.go
@@ -37,14 +37,14 @@ func TestSimpleFuncStack(t *testing.T) {
 		{
 			func() error { return innerFunc() },
 			[]string{
-				"github.com/nordcloud/ncerrors/errors/error.go(New):76",
+				"github.com/nordcloud/ncerrors/errors/error.go(New):100",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(innerFunc):10",
 			},
 		},
 		{
 			func() error { return outerFunc() },
 			[]string{
-				"github.com/nordcloud/ncerrors/errors/error.go(New):76",
+				"github.com/nordcloud/ncerrors/errors/error.go(New):100",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(innerFunc):10",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(outerFunc):14",
 			},
@@ -52,7 +52,7 @@ func TestSimpleFuncStack(t *testing.T) {
 		{
 			func() error { return testStruct{outerFunc}.method() },
 			[]string{
-				"github.com/nordcloud/ncerrors/errors/error.go(New):76",
+				"github.com/nordcloud/ncerrors/errors/error.go(New):100",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(innerFunc):10",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(outerFunc):14",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(testStruct.method):22",
@@ -61,7 +61,7 @@ func TestSimpleFuncStack(t *testing.T) {
 		{
 			func() error { return testStruct{innerFunc}.nested() },
 			[]string{
-				"github.com/nordcloud/ncerrors/errors/error.go(New):76",
+				"github.com/nordcloud/ncerrors/errors/error.go(New):100",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(innerFunc):10",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(testStruct.nested.func1):27",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(testStruct.nested):29",


### PR DESCRIPTION
Two new methods on `errors.Fields`:
  - `Add(key, val)` : adds a single item to existing `Fields` and return a new `Fields` instance
 - `Extend(Fields)`: similar, but extend existing `Fields` with provided `Fields`, as well returns new `Fields` instance

In both methods the existing keys can be overwritten.

Example:

```go

func handler(param string) {
 // some global error fields
  errorFields := errors.Fields{"param": param}
  ...
  if err := someOtherFunction(param2); err != nil {
    return errors.WithContext(err, "failed to call other function" , errorFields.Add("param2", param2))
  }
}

```