### PR TITLE
[KLAR-11010] Internal Go library ncerrors does not work with Is/As functions

### DIFF
--- a/errors/stack_trace.go
+++ b/errors/stack_trace.go
@@ -33,7 +33,7 @@ func getStackTraces() ([]string, *stack) {
 func GetTrace() []string {
 	stack, _ := getStackTraces()
 
-	return stack
+	return stack[1:]
 }
 
 type frame uintptr

--- a/errors/stack_trace_test.go
+++ b/errors/stack_trace_test.go
@@ -39,14 +39,14 @@ func TestSimpleFuncStack(t *testing.T) {
 		{
 			func() error { return innerFunc() },
 			[]string{
-				"github.com/nordcloud/ncerrors/errors/error.go(New):110",
+				"github.com/nordcloud/ncerrors/errors/error.go(New):135",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(innerFunc):12",
 			},
 		},
 		{
 			func() error { return outerFunc() },
 			[]string{
-				"github.com/nordcloud/ncerrors/errors/error.go(New):110",
+				"github.com/nordcloud/ncerrors/errors/error.go(New):135",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(innerFunc):12",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(outerFunc):16",
 			},
@@ -54,7 +54,7 @@ func TestSimpleFuncStack(t *testing.T) {
 		{
 			func() error { return testStruct{outerFunc}.method() },
 			[]string{
-				"github.com/nordcloud/ncerrors/errors/error.go(New):110",
+				"github.com/nordcloud/ncerrors/errors/error.go(New):135",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(innerFunc):12",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(outerFunc):16",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(testStruct.method):24",
@@ -63,7 +63,7 @@ func TestSimpleFuncStack(t *testing.T) {
 		{
 			func() error { return testStruct{innerFunc}.nested() },
 			[]string{
-				"github.com/nordcloud/ncerrors/errors/error.go(New):110",
+				"github.com/nordcloud/ncerrors/errors/error.go(New):135",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(innerFunc):12",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(testStruct.nested.func1):29",
 				"github.com/nordcloud/ncerrors/errors/stack_trace_test.go(testStruct.nested):31",
@@ -79,12 +79,12 @@ func TestSimpleFuncStack(t *testing.T) {
 func TestGetSingleTrace(t *testing.T) {
 	s := GetTrace()
 	// Returns list of the stack trace
-	assert.Len(t, s, 3)
-	assert.Equal(t, "github.com/nordcloud/ncerrors/errors/stack_trace_test.go(TestGetSingleTrace):80", s[1])
+	assert.Len(t, s, 2)
+	assert.Equal(t, "github.com/nordcloud/ncerrors/errors/stack_trace_test.go(TestGetSingleTrace):80", s[0])
 }
 
 func TestGetCallStackTrace(t *testing.T) {
 	s := GetTrace()
-	assert.Len(t, s, 3)
-	assert.Equal(t, "github.com/nordcloud/ncerrors/errors/stack_trace_test.go(TestGetCallStackTrace):87", s[1])
+	assert.Len(t, s, 2)
+	assert.Equal(t, "github.com/nordcloud/ncerrors/errors/stack_trace_test.go(TestGetCallStackTrace):87", s[0])
 }


### PR DESCRIPTION
- add Is/As methods for NCError type
- make Fields optional
- fix GetTrace function to return stacktrace wihtout 1 garbage line